### PR TITLE
Use newer version of cbjavaloader

### DIFF
--- a/box.json
+++ b/box.json
@@ -15,7 +15,7 @@
     "description":"A collection of string helper functions",
     "type":"modules",
     "dependencies":{
-        "cbjavaloader":"^1.3.3+25"
+        "cbjavaloader":"^2"
     },
     "devDependencies":{
         "testbox":"^2.4.0+80"


### PR DESCRIPTION
Trying to removing dependencies on different module version if not needed. Would you please accept this and publish a new version of str?