### PR TITLE
bugfix global var

### DIFF
--- a/models/Str.cfc
+++ b/models/Str.cfc
@@ -14,8 +14,8 @@ component singleton {
     }
 
     function slice( word, begin, end ) {
-        if ( isNull( end ) ) {
-            end = len( word );
+        if ( isNull( arguments.end ) ) {
+            arguments.end = len( word );
         }
         return mid( word, begin, end + 1 - begin );
     }


### PR DESCRIPTION
Checking for end instead of arguments.end and assigning end instead of arguments.end creates a global var in this model. And it is a singleton, so the second time you will call slice you can check for IsNull(end) but it will always have a value, and you never know which one.